### PR TITLE
Add GitHub actions for building and releasing 

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -24,14 +24,14 @@ jobs:
 
       # this is done to make it so the zip file in the download doesn't have a file structure
       - name: Copy README
-        run: copy ${{ github.workspace }}/USER_README.txt ${{ github.workspace}}/bin/Release/
+        run: copy ${{ github.workspace }}\USER_README.txt ${{ github.workspace}}\bin\Release\
 
       - name: Upload BBCF_IM
         uses: actions/upload-artifact@v3
         with:
           name: BBCF_IM
           path: |
-            ${{ github.workspace}}/bin/Release/dinput8.dll
-            ${{ github.workspace}}/bin/Release/settings.ini
-            ${{ github.workspace}}/bin/Release/palettes.ini
-            ${{ github.workspace}}/bin/Release/USER_README.txt
+            ${{ github.workspace}}\bin\Release\dinput8.dll
+            ${{ github.workspace}}\bin\Release\settings.ini
+            ${{ github.workspace}}\bin\Release\palettes.ini
+            ${{ github.workspace}}\bin\Release\USER_README.txt

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.3.1
 
       - name: Build BBCF_IM
         run: msbuild BBCF_IM.sln -property:Configuration=Release

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -1,0 +1,37 @@
+name: Build artifact on push to master or PR
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  build:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.0.2
+
+      - name: Build BBCF_IM
+        run: msbuild BBCF_IM.sln -property:Configuration=Release
+
+      # this is done to make it so the zip file in the download doesn't have a file structure
+      - name: Copy README
+        run: copy ${{ github.workspace }}/USER_README.txt ${{ github.workspace}}/bin/Release/
+
+      - name: Upload BBCF_IM
+        uses: actions/upload-artifact@v3
+        with:
+          name: BBCF_IM
+          path: |
+            ${{ github.workspace}}/bin/Release/dinput8.dll
+            ${{ github.workspace}}/bin/Release/settings.ini
+            ${{ github.workspace}}/bin/Release/palettes.ini
+            ${{ github.workspace}}/bin/Release/USER_README.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.3.1
+
+      - name: Build BBCF_IM
+        run: msbuild BBCF_IM.sln -property:Configuration=Release
+      
+      - name: Calculate checksums
+        working-directory: ${{ github.workspace}}\bin\Release\
+        run: |
+          $(CertUtil -hashfile dinput8.dll MD5)[1] -replace " ","" > dinput8.dll.md5
+          $(CertUtil -hashfile dinput8.dll SHA256)[1] -replace " ","" > dinput8.dll.sha256
+
+      # action-gh-release has issues with back slashes in file paths
+      # working-directory is also not supported
+      # see issue https://github.com/softprops/action-gh-release/issues/280
+      # for now, just use "." instead of "${{ github.workspace}}" and
+      # use forward slashes
+      - name: Release BBCF_IM
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ./bin/Release/dinput8.dll
+            ./bin/Release/dinput8.dll.md5
+            ./bin/Release/dinput8.dll.sha256
+            ./bin/Release/settings.ini
+            ./bin/Release/palettes.ini


### PR DESCRIPTION
This adds a couple of actions as follows:

- build-artifact.yml: builds an artifact for testing purposes on a push to master, PR, or modification of PR
- release.yml: builds and creates a release when a tag that matches "v*.*" is pushed