### PR TITLE
Fixing keep aspect ratio issue with the hitbox displayer

### DIFF
--- a/src/Overlay/Window/HitboxOverlay.h
+++ b/src/Overlay/Window/HitboxOverlay.h
@@ -11,7 +11,6 @@ typedef unsigned int uint32_t;
 class HitboxOverlay : public IWindow
 {
 public:
-	char* aspectRatioAddress;
 	bool drawOriginLine = false;
 	bool drawCharacterHitbox[2] = {true, true};
 
@@ -30,6 +29,7 @@ protected:
 	void AfterDraw() override;
 
 private:
+	void fixAspectRatio(ImVec2& point);
 	void DrawOriginLine(ImVec2 worldPos, float rotationRad);
 	void DrawCollisionAreas(const CharData* charObj, const ImVec2 playerWorldPos);
 
@@ -51,6 +51,12 @@ private:
 	float m_scale = 0.346f;
 	float m_rectThickness = 2.5f;
 	float m_rectFillTransparency = 0.5f;
+
+	// Aspect ratio fixes
+	ImGuiIO io;
+	const float aspectRatio = 5.0f / 3.0f;
+	float displayRatio;
+	const char* aspectRatioAddress;
 
 	ImGuiWindowFlags m_overlayWindowFlags = ImGuiWindowFlags_NoTitleBar
 		| ImGuiWindowFlags_NoInputs

--- a/src/Overlay/Window/HitboxOverlay.h
+++ b/src/Overlay/Window/HitboxOverlay.h
@@ -11,6 +11,7 @@ typedef unsigned int uint32_t;
 class HitboxOverlay : public IWindow
 {
 public:
+	char* aspectRatioAddress;
 	bool drawOriginLine = false;
 	bool drawCharacterHitbox[2] = {true, true};
 


### PR DESCRIPTION
there's normally a scaling issue when enabling the hitbox viewer while having keep aspect ratio on in fullscreen/borderless. This patch fixes it by checking if the option is enabled to then apply the proper scaling and offset to the hitbox rectangle position