### PR TITLE
Add setting for replay rewind autoopen

### DIFF
--- a/src/Core/settings.def
+++ b/src/Core/settings.def
@@ -19,6 +19,7 @@ SETTING(bool, vsync, "V-sync", "0");
 SETTING(int, menusize, "MenuSize", "2");
 SETTING(bool, notifications, "Notifications", "1");
 SETTING(bool, checkupdates, "CheckUpdates", "1");
+SETTING(bool, autoopenrewind, "AutoOpenRewind", "1");
 SETTING(bool, loadforeignpalettes, "LoadForeignPalettesToggleDefault", "1");
 SETTING(int, uploadReplayData, "UploadReplayData", "-1");
 SETTING(std::string, uploadReplayDataHost, "UploadReplayDataHost", "50.118.225.175");

--- a/src/Game/MatchState.cpp
+++ b/src/Game/MatchState.cpp
@@ -111,7 +111,7 @@ void MatchState::OnIntroPlaying()
 {
 	LOG(7, "MatchState::OnIntroPlaying\n");
 
-	if (*g_gameVals.pGameMode == GameMode_ReplayTheater) {
+	if (*g_gameVals.pGameMode == GameMode_ReplayTheater && Settings::settingsIni.autoopenrewind) {
 		WindowManager::GetInstance().GetWindowContainer()->GetWindow<ReplayRewindWindow>(WindowType_ReplayRewind)->Open();
 	}
 }

--- a/src/Overlay/Window/ReplayRewindWindow.cpp
+++ b/src/Overlay/Window/ReplayRewindWindow.cpp
@@ -3,6 +3,7 @@
 #include "Core/interfaces.h"
 #include "Game/SnapshotApparatus/SnapshotApparatus.h"
 #include "Game/gamestates.h"
+#include "Core/Settings.h"
 #include "Overlay/imgui_utils.h"
 
 unsigned int ReplayRewindWindow::count_entities(bool unk_status2) {
@@ -75,7 +76,7 @@ std::vector<int> ReplayRewindWindow::find_nearest_checkpoint(std::vector<unsigne
 }
 void ReplayRewindWindow::Draw()
 {
-    
+
 #ifdef _DEBUG
     ImGui::Text("Active entities: %d", ReplayRewindWindow::count_entities(false));
     ImGui::Text("Active entities with unk_status2 = 2: %d", count_entities(true));
@@ -97,6 +98,21 @@ void ReplayRewindWindow::Draw()
 
         return;
     }
+
+
+    static bool b = Settings::settingsIni.autoopenrewind;
+    if (ImGui::Checkbox("Automatically open this window", &b)) {
+        if (Settings::settingsIni.autoopenrewind) {
+            Settings::changeSetting("AutoOpenRewind", std::to_string(0));
+            b = false;
+        }
+        else {
+            Settings::changeSetting("AutoOpenRewind", std::to_string(1));
+            b = true;
+        }
+        Settings::loadSettingsFile();
+    }
+
     if (*(bbcf_base_adress + 0x8F7758) == 0) {
         if (!g_interfaces.player1.IsCharDataNullPtr() && !g_interfaces.player2.IsCharDataNullPtr()) {
             ImGui::BeginGroup();


### PR DESCRIPTION
Small PR.

Adds a setting for whether or not the replay rewind window automatically opens on replay start.
This setting can be toggled using a checkbox on the replay rewind window itself.

This may be helpful for people who want to automatically record a lot of replays while they go AFK, since having any ImGUI window open causes the cursor to appear on OBS.